### PR TITLE
change new and old key of the cr_phase event to new_phase and old_phase

### DIFF
--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -1020,8 +1020,8 @@ Examples of the transitions between phases are provided in <xref target="Example
 	         <!--- 	<name>cr_phase</name> -->
 <sourcecode type="cddl"><![CDATA[
 RecoveryCarefulResumePhaseUpdated = {
-? old: CarefulResumePhase,
-new: CarefulResumePhase,
+? old_phase: CarefulResumePhase,
+new_phase: CarefulResumePhase,
 state_data: CarefulResumeStateParameters,
 ? restored_data: CarefulResumeRestoredParameters,
 ? trigger:


### PR DESCRIPTION
In some programming languages, the `new` operator is used to allocate bytes for a new object. 

It might be better to use a different field key for the old and new entry in the cr_phase event. 

