### PR TITLE
Add specification for resuming BBR

### DIFF
--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -548,11 +548,11 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
                  added to the BBR state, and initialized
                  to "False" when the BBR flow starts.</t>
               <t>Careful Resume is only activated if a BBR flow is in the Startup state</t>
-              <t>The probing rate is set 1/2 of the bottleneck bandwidth remembered in
+              <t>The probing rate is set to 1/2 of the bottleneck bandwidth in
                  the saved congestion control parameters,
               <t>The sender starts the Unvalidated Phase at the beginning of a round,
                  and sets the "carefully-resuming" flags to "True".
-              <t>When the "carefully-resuming" is set, the sender sets the pacing rate
+              <t>When the "carefully-resuming" flag is set, the sender sets the BBR pacing rate
                  to the larger of the nominal pacing rate (BBR.bw times BBRStartupPacingGain)
                  and the probing rate. The CWND is set to the largest of BBR.bw
                  and the probing rate, multiplied by BBR.rtt_min times
@@ -560,7 +560,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
               <t>The "carefully-resuming" flag is reset to False two rounds after
                  it is set, i.e., after all the packets sent in the first round
                  of "carefully resuming"
-                 have been received and acknowledged by the peer. At that stage,
+                 have been received and acknowledged by the peer. At that stage (after the capacity has been validated),
                  the measured delivery rate is expected to reflect the probing rate.</t>
            </list></t>
         <t>Implementation notes are provided in <xref target="req-unvalid"></xref>. </t>

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -1358,17 +1358,18 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
 
     <section anchor="Examples-no loss" title="Example with No Loss">
         <t>In the first example of using Careful Resume,
-        the sender starts by sending IW (10) packets in the Reconnaissance Phase,
+        the sender starts by sending IW packets, assumed to be 10 packets, in the Reconnaissance Phase,
         and then continues in a subsequent RTT to send more packets until the sender
         becomes CWND-limited (i.e., flight_size = CWND).</t>
             
-        <t>The sender then
+        <t>The sender in the Reconaissance Phase then
         confirms the RTT and other conditions for using Careful Resume.
-        In this example, this is confirmed when the sender has 29 packets in flight.
-        The sender then enters the Unvalidated Phase.
-        (This confirmation could have happened earlier if data was available to send.) The
-        sender initialises the PipeSize to the CWND (the same as the flight_size, i.e., 29 packets)
-        and then sets the CWND to 150 packets (based upon a previously
+        In this example, this is confirmed when the sender has 29 packets in flight.</t>
+        <t>The sender then enters the Unvalidated Phase.
+        (This path confirmation could have happened earlier if data had been available to send.) The
+        sender initialises the PipeSize to the CWND
+        (at this time this is the same as the flight_size, i.e., 29 packets)
+        and then sets the CWND to 150 packets (based upon half of the previously
         observed saved_cwnd of 300 packets).</t>
             
         <t>The sender now sends 121 unvalidated packets (the unused portion of the current CWND).
@@ -1380,11 +1381,11 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
 
         <t>When the first unvalidated packet is acknowledged (packet number 30) the sender
         enters the Validating Phase. (This transition would also occur if the flight_size increased to equal CWND.)
-        During this phase, the CWND can be increased for each ACK acknowledging an unvalidated packet, because
+        During this phase, the CWND can be increased for each ACK that acknowledges an unvalidated packet, because
         this indicates that the packet was indeed validated.</t>
 
-        <t>When an ACK is received for the last packet sent in the Unvalidated Phase,
-        the sender completes using Careful Resume. It enters the Normal Phase. If CWND is less than ssthresh,
+        <t>When an ACK is received for the last packet that was sent in the Unvalidated Phase,
+        the sender completes using Careful Resume. It then enters the Normal Phase. If CWND is less than ssthresh,
         a Reno or Cubic sender in the Normal Phase is permitted to use Slow-Start to grow the CWND towards
         the ssthresh, and will then enter congestion avoidance.</t>
     </section>
@@ -1407,10 +1408,8 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
         The PipeSize also increases with each ACK received, to reflect the discovered capacity.</t>
 
         <t>When an ACK is received for the last packet sent in the Unvalidated Phase,
-        the sender has completed using Careful Resume. It then enters the Normal Phase.
-        If the CWND is less than ssthresh,
-        a Reno or Cubic sender in the Normal Phase is permitted to use Slow-Start to grow the CWND towards
-        the ssthresh, and will then enter congestion avoidance.</t>
+        the sender has completed using Careful Resume. It then enters the Normal Phase,
+        as in the example with no loss.</t>
     </section>
 
     <section anchor="Examples-loss-recon" title="Example with Loss detected in the Reconnaissance Phase">
@@ -1426,28 +1425,28 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
 
         <t>The sender now sends 121 unvalidated packets (the remaining unused CWND).
         This example considers the case when one of the unvalidated packet is lost, which
-        we choose to be packet 64 (the 35th packet in the Unvalidated Phase).</t>
+        we choose to be packet 64 (the 35th packet sent in the Unvalidated Phase).</t>
 
         <t>ACKs confirm the first 34 unvalidated packets are received without loss.
         The PipeSize at this point is equal to 63 (29 + 34) packets.</t>
             
         <t>The loss is then detected (by a timer or by receiving three ACKs that do not cover packet number 35),
         the sender then enters the Safe Retreat Phase because the window was not validated.
-        The PipeSize at this point is equal to 66 (29 + 34) packets. Assuming IW=10.
-        The CWND is reset to Max(10,PS/2) = Max(10,66/2) = 33 packets.
+        The PipeSize at this point is equal to 66 (29 + 34) packets. Assuming that the IW was 10 packets,
+        the CWND is reset to Max(10,PS/2) = Max(10,66/2) = 33 packets.
         This CWND is used during the Safe Retreat Phase, because congestion was detected and the
-        sender still does not know if the remaining unvalidated packets will be
+        sender still does not yet know if the remaining unvalidated packets will be
         successfully acknowledged. A conservative CWND calculation ensures the sender drains
         the path after this potentially severe congestion event.
         There is no further increase in CWND in this phase.</t>
 
-        <t>The sender continues to receives ACKs for the remaining  86 (121-35) unvalidated packets.
+        <t>The sender continues to receive ACKs for the remaining  86 (121-35) unvalidated packets.
         Recall that the 35th unvalidated packet was lost and had packet number 64 (29+35).
         The PipeSize tracks the
-        size of the pipe discovered by the unvalidated packets and
-        continues to be further increased as each ACK acknowledges new data.
-        Although the PipeSize cannot be used to safety initialise CWND (because it was measured when the sender
-        aggressively created overload), the estimated PipeSize
+        capacity discovered by acknowledgments for the unvalidated packets and
+        continues to be further increased for each received ACK acknowledges new data.
+        Although the PipeSize cannot be used to safety initialise the CWND (because it was measured when the sender
+        had aggressively created overload), the estimated PipeSize
         (which, in this case, is 121-1 = 120 packets) can be used to set the ssthresh on exit
         from Safe Retreat, since it does indicate an upper limit to the current capacity.</t>
 

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -171,7 +171,11 @@ specify just the year. -->
     the saved_cwnd for the path and the minimum Round Trip Time (RTT). These
     parameters are saved and used to modify the CC
     behavior of a subsequent connection between the
-    same endpoints.</t>
+    same endpoints. Some congestion control algorithms may use other parameters.
+    For example, implementations using BBR will want to also retain the
+    value of the sending rate required to reach the full bandwidth available to
+    the flow (BBR.max_bw, see <xref target="I-D.cardwell-iccrg-bbr-congestion-control"></xref>).
+    </t>
 
     <t>When used with the QUIC transport, this provides transport services that resemble
     those that could be implemented in TCP, using methods such as TCP Control Block (TCB)
@@ -536,6 +540,20 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
          (see first_unvalidated_packet_acknowledged in <xref target="sec-QLOG"></xref>).</t>
         </list></t> <!-- End of list of actions -->
 
+        <t>When the flow is controlled using BBR, the careful resume is implemented
+           by setting the pacing rate from the remembered values, with the following
+           precautions:</t>
+           <t><list style="symbols">
+              <t>Careful resume is only activated if the flow is in the Startup state</t>
+              <t>The value of the BBR.bw parameter at the beginning of the next round
+                 is only updated if the current value is lower than the remembered value
+                 of BBR.bw_max.</t>
+              <t>In order to avoid disrupting existing connections, the value of BBR.bw
+                 is only incremented by half the remembered value of BBR.bw_max.</t>
+              <t>The increment is only valid for one round. For the next round, the BBR.bw
+                 parameter will based as specified in the BBR specification, based on
+                 observed values of RTT and delivery rate.</t>
+           </list></t>
         <t>Implementation notes are provided in <xref target="req-unvalid"></xref>. </t>
     </section> <!-- End of define Unvalidated Phase -->
 
@@ -580,8 +598,13 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             received for the last packet number (or higher)
             that was sent in the Unvalidated Phase
             (see last_unvalidated_packet_acknowledged in <xref target="sec-QLOG"></xref>).</t>
-
         </list></t> <!-- End of list of actions -->
+        <t>When using BBR, validation is performed using the regular BBR rules
+           for exiting Startup. The measured delivery rate will reflect the
+           actual capacity of the network. If congestion was experienced and
+           packet losses were observed, BBR will exit the Startup state and enter the
+           Drain state.</t>
+
     </section> <!-- End of define Validating Phase -->
     
     <section anchor="sec-phase-ret-phase" title="Safe Retreat Phase">
@@ -636,6 +659,10 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             The value of ssthresh on leaving the Safe Retreat Phase
             MUST NOT be more than the PipeSize.</t>
         </list></t>
+
+        <t>The safe retreat process is not used when the connection uses BBR. Instead,
+           if the remembered values were excessive, BBR will naturally enter its Drain
+           state. </t>
      
         <t>Implementation notes are provided in <xref target="req-retreat"></xref>.</t>
 
@@ -660,10 +687,9 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
 
     <section title="RTO Expiry while using Careful Resume">
 
-
         <t> A sender that experiences a Retransmission Time Out (RTO) expiry
         ceases to use Careful Resume.
-        The sender enters the Normal Phase.</t>
+        The sender enters the Normal Phase. If using BBR, it will enter the Drain state.</t>
 
         <t> As in loss recovery, data sent in the
         Unvalidated Phase could be later acknowledged after an RTO event
@@ -1282,6 +1308,8 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
 
         <seriesInfo name="ACM CoNEXT" value="" />
       </reference>
+
+      
     </references>
 
 <section anchor="Examples" title="Notes on the Careful Resume Phases">

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -172,8 +172,8 @@ specify just the year. -->
     parameters are saved and used to modify the CC
     behavior of a subsequent connection between the
     same endpoints. Some congestion control algorithms may use other parameters.
-    For example, implementations using BBR will want to also retain the
-    value of the sending rate required to reach the full bandwidth available to
+    For example, implementations using BBR also retain the
+    value of the bottleneck bandwidth required to reach the capacity available to
     the flow (BBR.max_bw, see <xref target="I-D.cardwell-iccrg-bbr-congestion-control"></xref>).
     </t>
 
@@ -540,19 +540,28 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
          (see first_unvalidated_packet_acknowledged in <xref target="sec-QLOG"></xref>).</t>
         </list></t> <!-- End of list of actions -->
 
-        <t>When the flow is controlled using BBR, the careful resume is implemented
-           by setting the pacing rate from the remembered values, with the following
-           precautions:</t>
+        <t>When the flow is controlled using BBR, the Careful Resume is implemented
+           by setting the pacing rate from the saved congestion control parameters,
+           with the following precautions:</t>
            <t><list style="symbols">
-              <t>Careful resume is only activated if the flow is in the Startup state</t>
-              <t>The value of the BBR.bw parameter at the beginning of the next round
-                 is only updated if the current value is lower than the remembered value
-                 of BBR.bw_max.</t>
-              <t>In order to avoid disrupting existing connections, the value of BBR.bw
-                 is only incremented by half the remembered value of BBR.bw_max.</t>
-              <t>The increment is only valid for one round. For the next round, the BBR.bw
-                 parameter will based as specified in the BBR specification, based on
-                 observed values of RTT and delivery rate.</t>
+              <t>The flags "carefully-resuming" and "carefully-evaluating" are
+                 added to the BBR state, and initialized
+                 to "False" when the BBR flow starts.</t>
+              <t>Careful Resume is only activated if a BBR flow is in the Startup state</t>
+              <t>The sender starts the "evaluation" phase at the beginning of a round,
+                 and sets the "carefully-resuming" and "carefully-evaluating" flags to "True".
+              <t>When the "carefully-resuming" is set, the sender sets the pacing rate
+                 to the larger of the nominal pacing rate (BBR.bw times BBRStartupPacingGain)
+                 and the remembered value of BBR.bw_max. If the nominal pacing rate
+                 is higher, the "carefully-resuming" flag is reset to False.
+              <t>The "carefully-resuming" flag is in any case reset to False at the
+                 beginning of the next round.
+              <t>The "carefully-evaluating" flag is reset to False two rounds after
+                 it is set, i.e., after all the packets sent when "carefully resuming"
+                 have been received and acknowledged by the peer. At that stage,
+                 the measured delivery rate is expected to reflect the capacity of
+                 the path.
+              </t>
            </list></t>
         <t>Implementation notes are provided in <xref target="req-unvalid"></xref>. </t>
     </section> <!-- End of define Unvalidated Phase -->
@@ -602,8 +611,9 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
         <t>When using BBR, validation is performed using the regular BBR rules
            for exiting Startup. The measured delivery rate will reflect the
            actual capacity of the network. If congestion was experienced and
-           packet losses were observed, BBR will exit the Startup state and enter the
-           Drain state.</t>
+           packet losses were observed, BBR will exit the Startup state
+           and enter the Drain state while the "carefully-evaluating" flag is still
+           True, which will trigger the "safe retreat" option of the Drain state.</t>
 
     </section> <!-- End of define Validating Phase -->
     
@@ -660,9 +670,15 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             MUST NOT be more than the PipeSize.</t>
         </list></t>
 
-        <t>The safe retreat process is not used when the connection uses BBR. Instead,
-           if the remembered values were excessive, BBR will naturally enter its Drain
-           state. </t>
+        <t>When using BBR, the "safe retreat" mode is applied if the Drain
+           state is entered while the "carefully-evaluating" flag is still
+           True, i.e., if less than 2 full rounds have elapsed before
+           the Careful Resume attempt. The delivery rate measured in this
+           conditions are tainted, because packets sent during the attempt
+           are still queued at the bottleneck and may have "pushed out"
+           competing traffic. The delivery rates measured in Drain state
+           MUST be discarded if the "carefully-evaluating" flag is True.
+           This flag is only cleared upon exiting the Drain state.</t>
      
         <t>Implementation notes are provided in <xref target="req-retreat"></xref>.</t>
 

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -361,7 +361,7 @@ specify just the year. -->
     uses Careful Resume.</t>
 
     <t>
-<figure title="Key transistions between Phases in Careful Resume">
+<figure title="Key transitions between Phases in Careful Resume">
 <artwork align="left" name="" type="" alt=""><![CDATA[
      
 Observing ...> Connect -> Reconnaissance --------------------> Normal
@@ -517,10 +517,10 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
      </list></t>
         <t>The following actions are performed during the Unvalidated Phase:</t>
         <t><list style="symbols">
-             <t>Unvalidated Phase (Pacing tranmission): All packet sent in the
+             <t>Unvalidated Phase (Pacing transmission): All packet sent in the
            Unvalidated Phase MUST use based on the current_rtt.</t>
              
-             <t>Unvalidated Phase (Confirming the path during tranmssion):
+             <t>Unvalidated Phase (Confirming the path during transmission):
              If a sender determines that the previous CC parameters
              are not valid (due to a detected path change),
              the Safe Retreat Phase is entered.
@@ -550,7 +550,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
               <t>Careful Resume is only activated if a BBR flow is in the Startup state</t>
               <t>The probing rate is set 1/2 of the bottleneck bandwidth remembered in
                  the saved congestion control parameters,
-              <t>The sender starts the "evaluation" phase at the beginning of a round,
+              <t>The sender starts the Unvalidated Phase at the beginning of a round,
                  and sets the "carefully-resuming" flags to "True".
               <t>When the "carefully-resuming" is set, the sender sets the pacing rate
                  to the larger of the nominal pacing rate (BBR.bw times BBRStartupPacingGain)
@@ -673,8 +673,8 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
         <t>When using BBR, the "safe retreat" mode is applied if the Drain
            state is entered while the "carefully-resuming" flag is still
            True, i.e., if less than 2 full rounds have elapsed after
-           the Careful Resume attempt. The delivery rates measured in this
-           conditions are tainted, because packets sent during the attempt
+           the sender entered the Unvalidated Phase. The delivery rates measured in
+           these conditions are tainted, because packets sent during the attempt
            are still queued at the bottleneck and may have "pushed out"
            competing traffic. The delivery rates measured in Drain state
            MUST be discarded if the "carefully-resuming" flag is set to True.

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -850,7 +850,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
         the saved CC parameters. When multiple new concurrent connections
         are made to a server, each can have a valid saved_endpoint_token,
         but the saved_cwnd can once (i.e., if two connections start
-        simulateously they cannot both use the saved_cwnd to perform a jump).
+        simultaneously they cannot both use the saved_cwnd to perform a jump).
         This is to prevent a sender from performing multiple jumps in the CWND,
         each individually based on the same saved_cwnd, and hence creating an
         excessive aggregate load at the bottleneck.</t>

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -540,7 +540,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
          (see first_unvalidated_packet_acknowledged in <xref target="sec-QLOG"></xref>).</t>
         </list></t> <!-- End of list of actions -->
 
-        <t>When the flow is controlled using BBR, the Careful Resume is implemented
+        <t>When the flow is controlled using BBR, Careful Resume is implemented
            by setting the pacing rate from the saved congestion control parameters,
            with the following precautions:</t>
            <t><list style="symbols">

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -546,17 +546,17 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
            <t><list style="symbols">
               <t>The flag "carefully-resuming" is
                  added to the BBR state, and initialized
-                 to "False" when the BBR flow starts.</t>
-              <t>Careful Resume is only activated if a BBR flow is in the Startup state</t>
+                 to "False" when the BBR flow starts;</t>
+              <t>Careful Resume is only activated if a BBR flow is in the Startup state;</t>
               <t>The probing rate is set to 1/2 of the bottleneck bandwidth in
-                 the saved congestion control parameters,
+                 the saved congestion control parameters.</t>
               <t>The sender starts the Unvalidated Phase at the beginning of a round,
-                 and sets the "carefully-resuming" flags to "True".
+                 and sets the "carefully-resuming" flags to "True";</t>
               <t>When the "carefully-resuming" flag is set, the sender sets the BBR pacing rate
                  to the larger of the nominal pacing rate (BBR.bw times BBRStartupPacingGain)
                  and the probing rate. The CWND is set to the largest of BBR.bw
                  and the probing rate, multiplied by BBR.rtt_min times
-                 BBRStartupCwndGain.
+                 BBRStartupCwndGain;</t>
               <t>The "carefully-resuming" flag is reset to False two rounds after
                  it is set, i.e., after all the packets sent in the first round
                  of "carefully resuming"
@@ -1146,15 +1146,18 @@ state_data: CarefulResumeStateParameters,
         "congestion_window_limited" /
         ; for the Validating phase
         "first_unvalidated_packet_acknowledged" /
-    ; for the Normal phase, and no remaining unvalidated packets to be acknowledged
+    ; for the Normal phase
+    ; and no remaining unvalidated packets to be acknowledged
         "last_unvalidated_packet_acknowledged" /
         ; for the Normal phase, when CR not allowed
         "rtt_not_validated" /
-        ; for the Normal phase, when the application sends fewer unvalidated packets than permitted by CWND
+        ; for the Normal phase,
+        ; when sending fewer unvalidated packets than CWND permits
         "rate_limited" /
     ; for the Safe Retreat phase, when loss detected
         "packet_loss" /
-    ; for the Safe Retreat phase, when ECN congestion experienced reported
+    ; for the Safe Retreat phase, 
+    ; when ECN congestion experienced reported
         "ECN_CE" /
         ; for the Normal phase 1 RTT after a congestion event
         "exit_recovery"
@@ -1536,7 +1539,8 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
         <t>WG-09, Cleaning text to separate guidelines and specification
         and adjust wording to improve clarity based on questions received during implementation.
         </t>
-        <t>WG-10, CH developed text to explain expected operation with BBR. This also fixed some typos introduced in previous edits.</t>
+        <t>WG-10, CH developed text to explain expected operation with BBR. 
+        This also fixed some typos introduced in previous edits. Fix XML and fix CDDL bugs for submission.</t>
     </list></t>
 </section> <!-- End of Revisions -->
 

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -1536,7 +1536,7 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
         <t>WG-09, Cleaning text to separate guidelines and specification
         and adjust wording to improve clarity based on questions received during implementation.
         </t>
-
+        <t>WG-10, CH developed text to explain expected operation with BBR. This also fixed some typos introduced in previous edits.</t>
     </list></t>
 </section> <!-- End of Revisions -->
 

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -670,7 +670,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             MUST NOT be more than the PipeSize.</t>
         </list></t>
 
-        <t>When using BBR, the "safe retreat" mode is applied if the Drain
+        <t>When using BBR, the Safe Retreat Phase is entered if the Drain
            state is entered while the "carefully-resuming" flag is still
            True, i.e., if less than 2 full rounds have elapsed after
            the sender entered the Unvalidated Phase. The delivery rates measured in

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -361,7 +361,7 @@ specify just the year. -->
     uses Careful Resume.</t>
 
     <t>
-<figure title="Key transitions between Phases in Careful Resume">
+<figure title="Key transistions between Phases in Careful Resume">
 <artwork align="left" name="" type="" alt=""><![CDATA[
      
 Observing ...> Connect -> Reconnaissance --------------------> Normal
@@ -517,10 +517,10 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
      </list></t>
         <t>The following actions are performed during the Unvalidated Phase:</t>
         <t><list style="symbols">
-             <t>Unvalidated Phase (Pacing transmission): All packet sent in the
+             <t>Unvalidated Phase (Pacing tranmission): All packet sent in the
            Unvalidated Phase MUST use based on the current_rtt.</t>
              
-             <t>Unvalidated Phase (Confirming the path during transmission):
+             <t>Unvalidated Phase (Confirming the path during tranmssion):
              If a sender determines that the previous CC parameters
              are not valid (due to a detected path change),
              the Safe Retreat Phase is entered.
@@ -672,13 +672,13 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
 
         <t>When using BBR, the "safe retreat" mode is applied if the Drain
            state is entered while the "carefully-evaluating" flag is still
-           True, i.e., if less than 2 full rounds have elapsed before
-           the Careful Resume attempt. The delivery rate measured in this
+           True, i.e., if less than 2 full rounds have elapsed after
+           the Careful Resume attempt. The delivery rates measured in this
            conditions are tainted, because packets sent during the attempt
            are still queued at the bottleneck and may have "pushed out"
            competing traffic. The delivery rates measured in Drain state
            MUST be discarded if the "carefully-evaluating" flag is True.
-           This flag is only cleared upon exiting the Drain state.</t>
+           This flag is cleared upon exiting the Drain state.</t>
      
         <t>Implementation notes are provided in <xref target="req-retreat"></xref>.</t>
 
@@ -705,7 +705,10 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
 
         <t> A sender that experiences a Retransmission Time Out (RTO) expiry
         ceases to use Careful Resume.
-        The sender enters the Normal Phase. If using BBR, it will enter the Drain state.</t>
+        The sender enters the Normal Phase. If using BBR, the normal
+        processing of packet losses will cause it to enter the
+        Drain state while the "carefully-evaluating" flag is set to True,
+        which will force the Safe Retreat mode.</t>
 
         <t> As in loss recovery, data sent in the
         Unvalidated Phase could be later acknowledged after an RTO event
@@ -847,7 +850,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
         the saved CC parameters. When multiple new concurrent connections
         are made to a server, each can have a valid saved_endpoint_token,
         but the saved_cwnd can once (i.e., if two connections start
-        simultaneously they cannot both use the saved_cwnd to perform a jump).
+        simulateously they cannot both use the saved_cwnd to perform a jump).
         This is to prevent a sender from performing multiple jumps in the CWND,
         each individually based on the same saved_cwnd, and hence creating an
         excessive aggregate load at the bottleneck.</t>
@@ -1373,7 +1376,7 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
 |Phase:|(as      |FS=CWND, |or >1 RTT   |>= last    |>= last     |
 |      |needed)  |Lifetime,|has passed  |unvalidated|unvalidated |
 |      |         |and RTT  |or ACK for  |packet),   |packet),    |
-|      |         |confirmed|>= first    |enter      |{ssthresh=PS|
+|      |         |confirmed|>= last     |enter      |{ssthresh=PS|
 |      |         |), enter |unvalidated |Normal     |and enter   |
 |      |         |Unvalidat|packet),    |           |Normal}     |
 |      |         |ing else |enter       |           |            |
@@ -1406,7 +1409,7 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
         and then continues in a subsequent RTT to send more packets until the sender
         becomes CWND-limited (i.e., flight_size = CWND).</t>
             
-        <t>The sender in the Reconnaissance Phase then
+        <t>The sender in the Reconaissance Phase then
         confirms the RTT and other conditions for using Careful Resume.
         In this example, this is confirmed when the sender has 29 packets in flight.</t>
         <t>The sender then enters the Unvalidated Phase.

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -544,24 +544,24 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
            by setting the pacing rate from the saved congestion control parameters,
            with the following precautions:</t>
            <t><list style="symbols">
-              <t>The flags "carefully-resuming" and "carefully-evaluating" are
+              <t>The flag "carefully-resuming" is
                  added to the BBR state, and initialized
                  to "False" when the BBR flow starts.</t>
               <t>Careful Resume is only activated if a BBR flow is in the Startup state</t>
+              <t>The probing rate is set 1/2 of the bottleneck bandwidth remembered in
+                 the saved congestion control parameters,
               <t>The sender starts the "evaluation" phase at the beginning of a round,
-                 and sets the "carefully-resuming" and "carefully-evaluating" flags to "True".
+                 and sets the "carefully-resuming" flags to "True".
               <t>When the "carefully-resuming" is set, the sender sets the pacing rate
                  to the larger of the nominal pacing rate (BBR.bw times BBRStartupPacingGain)
-                 and the remembered value of BBR.bw_max. If the nominal pacing rate
-                 is higher, the "carefully-resuming" flag is reset to False.
-              <t>The "carefully-resuming" flag is in any case reset to False at the
-                 beginning of the next round.
-              <t>The "carefully-evaluating" flag is reset to False two rounds after
-                 it is set, i.e., after all the packets sent when "carefully resuming"
+                 and the probing rate. The CWND is set to the largest of BBR.bw
+                 and the probing rate, multiplied by BBR.rtt_min times
+                 BBRStartupCwndGain.
+              <t>The "carefully-resuming" flag is reset to False two rounds after
+                 it is set, i.e., after all the packets sent in the first round
+                 of "carefully resuming"
                  have been received and acknowledged by the peer. At that stage,
-                 the measured delivery rate is expected to reflect the capacity of
-                 the path.
-              </t>
+                 the measured delivery rate is expected to reflect the probing rate.</t>
            </list></t>
         <t>Implementation notes are provided in <xref target="req-unvalid"></xref>. </t>
     </section> <!-- End of define Unvalidated Phase -->
@@ -612,7 +612,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
            for exiting Startup. The measured delivery rate will reflect the
            actual capacity of the network. If congestion was experienced and
            packet losses were observed, BBR will exit the Startup state
-           and enter the Drain state while the "carefully-evaluating" flag is still
+           and enter the Drain state while the "carefully-resuming" flag is still
            True, which will trigger the "safe retreat" option of the Drain state.</t>
 
     </section> <!-- End of define Validating Phase -->
@@ -671,13 +671,13 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
         </list></t>
 
         <t>When using BBR, the "safe retreat" mode is applied if the Drain
-           state is entered while the "carefully-evaluating" flag is still
+           state is entered while the "carefully-resuming" flag is still
            True, i.e., if less than 2 full rounds have elapsed after
            the Careful Resume attempt. The delivery rates measured in this
            conditions are tainted, because packets sent during the attempt
            are still queued at the bottleneck and may have "pushed out"
            competing traffic. The delivery rates measured in Drain state
-           MUST be discarded if the "carefully-evaluating" flag is True.
+           MUST be discarded if the "carefully-resuming" flag is set to True.
            This flag is cleared upon exiting the Drain state.</t>
      
         <t>Implementation notes are provided in <xref target="req-retreat"></xref>.</t>
@@ -707,7 +707,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
         ceases to use Careful Resume.
         The sender enters the Normal Phase. If using BBR, the normal
         processing of packet losses will cause it to enter the
-        Drain state while the "carefully-evaluating" flag is set to True,
+        Drain state while the "carefully-resuming" flag is set to True,
         which will force the Safe Retreat mode.</t>
 
         <t> As in loss recovery, data sent in the
@@ -1079,7 +1079,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             <t>For NewReno and CUBIC, it is recommended to exit Slow-Start
             and enter the congestion avoidance phase of the CC algorithm.</t>
 
-            <t>For BBR CC, it is recommended to enter the "probe bandwidth"
+            <t>For BBR CC, it is recommended to enter the "Drain"
             state.</t>
         </list></t>-->
 


### PR DESCRIPTION
The careful resume behavior when using BBR is significantly different:

* the key variable is the bottleneck bandwidth, which should be remembered, encoded in token, etc.
* the test is done by overriding the BW value derived from previous measurement by the remembered value.
* during startup, BBR operates in rounds. At the end of the round, it measures the actual delivered bandwidth. The overriding is done for just one round. The next rounds revert to using values derived from measured bandwidth, i.e., reflecting the state of the network.
* if the data rate increase was successful, future measurements will reflect that, and startup continues per spec.
* if the data rate increase was excessive but did not cause packet losses, BBR will exit startup per spec when 3 successive rounds do not show any increase.
* if the increase was excessive but did cause packet losses, BBR will exit Startup and enter the Drain phase. This obviates the need for a "careful retreat" phase.
