### PR TITLE
Update draft-ietf-tsvwg-careful-resume.xml

### DIFF
--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -750,14 +750,18 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
 
             <t>Safe Retreat Phase (Acknowledgement of unvalidated packets):
             The sender enters Normal Phase
-            when it receives an acknowledgement for the last packet (or a later packet) sent during the
-            Unvalidated Phase and, if required,
-            adjusts the ssthresh (see exit_recovery in <xref target="sec-QLOG"></xref>).
-            Note: this does not imply that all packets need to be cumulatively acknowledged, only
-            that all packets sent in the Unvalidated Phase have been either acknowledged
-             or declared lost.
-            The value of ssthresh on leaving the Safe Retreat Phase
-            MUST NOT be more than the PipeSize.</t>
+            when the last packet (or a later packet) sent during the
+            Unvalidated Phase has been acknowledged. On leaving
+            the Safe Retreat Phase, the ssthresh MUST be set no larger than
+            the most recently measured PipeSize. In addition, specific
+            congestion control algorithms can further constrain this
+            to reduce the probability of a second round of congestion:
+            For Reno, the resultant ssthresh MUST be no larger than a
+            half of the recently measured PipeSize <xref target="RFC5681"></xref>.
+            Other congestion control
+            algorithms also scale the value used for ssthresh,
+            e.g., for Cubic, ssthresh is Beta__cubic <xref target="RFC9438"></xref> times PipeSize.
+            (The log is updated to exit_recovery, see <xref target="sec-QLOG"></xref>.)</t>
         </list></t>
 
         <t>When using BBR, the Safe Retreat Phase is entered if the Drain

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -654,7 +654,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
     </section> <!-- End of define Unvalidated Phase -->
 
     <section anchor="sec-phase-val-phase" title="Validating Phase">
-        <t>The Validating Phase checks if the packets
+        <t>The Validating Phase checks whether all packets
         sent in the Unvalidated Phase were received without inducing congestion.
         The CWND remains unvalidated and the sender typically remains in this phase for one RTT.
         On entry to the Validating Phase, the sender:</t>

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -603,8 +603,8 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
      </list></t>
         <t>The following actions are performed during the Unvalidated Phase:</t>
         <t><list style="symbols">
-             <t>Unvalidated Phase (Pacing transmission): All packet sent in the
-           Unvalidated Phase MUST use based on the current_rtt.</t>
+             <t>Unvalidated Phase (Pacing transmission): All packets sent in the
+           Unvalidated Phase MUST use pacing based on the current_rtt.</t>
              
              <t>Unvalidated Phase (Confirming the path during transmission):
              If a sender determines that the previous CC parameters
@@ -653,7 +653,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
     </section> <!-- End of define Unvalidated Phase -->
 
     <section anchor="sec-phase-val-phase" title="Validating Phase">
-        <t>The Validating Phase checks that all packets
+        <t>The Validating Phase checks if all the packets
         sent in the Unvalidated Phase were received without inducing congestion.
         The CWND remains unvalidated and the sender typically remains in this phase for one RTT.
         On entry to the Validating Phase, the sender:</t>
@@ -747,11 +747,13 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             <t>Safe Retreat Phase (Maintaining CWND):
             The CWND MUST NOT be increased in the Safe Retreat Phase.</t>
 
-            <t>Safe Retreat Phase (Acknowledgement of all unvalidated packets):
+            <t>Safe Retreat Phase (Acknowledgement of unvalidated packets):
             The sender enters Normal Phase
-            when the last packet (or a later packet) sent during the
-            Unvalidated Phase has been acknowledged, and if required
+            when it receives an acknowledgement for the last packet (or a later packet) sent during the
+            Unvalidated Phase and, if required,
             adjusts the ssthresh (see exit_recovery in <xref target="sec-QLOG"></xref>).
+            Note: this does not imply that all packets need to be culmulatively acknowledged, only
+            that the last packet (or later) was received.
             The value of ssthresh on leaving the Safe Retreat Phase
             MUST NOT be more than the PipeSize.</t>
         </list></t>
@@ -1404,7 +1406,7 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
 |Next  |Observing|If (     |If (FS=CWND |If (ACK    |If (ACK     |
 |Phase:|(as      |FS=CWND, |or >1 RTT   |>= last    |>= last     |
 |      |needed)  |Lifetime,|has passed  |unvalidated|unvalidated |
-|      |         |and RTT  |or ACK for  |packet),   |packet),    |
+|      |         |and RTT  |or ACK      |packet),   |packet),    |
 |      |         |confirmed|>= last     |enter      |{ssthresh=PS|
 |      |         |), enter |unvalidated |Normal     |and enter   |
 |      |         |Unvalidat|packet),    |           |Normal}     |
@@ -1416,7 +1418,7 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
 </figure>
     </t>
     <t>The following abbreviations are used
-    SS = Slow-Start FS = flight_size; PS = PipeSize; ACK = acknowledgement.
+    SS = Slow-Start FS = flight_size; PS = PipeSize; ACK = highest acknowledged packet.
     The PipeSize tracks the validated part of the cwnd. It is set to the CWND
     on entry to the Unvalidated Phase and
     is updated as each additional packet is acknowledged.</t>

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -644,16 +644,16 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
                  and the probing rate, multiplied by BBR.rtt_min times
                  BBRStartupCwndGain;</t>
               <t>The "carefully-resuming" flag is reset to False two rounds after
-                 it is set, i.e., after all the packets sent in the first round
+                 it is set, i.e., after an acknowledgment indicating that the packets sent in the first round
                  of "carefully resuming"
-                 have been received and acknowledged by the peer. At that stage (after the capacity has been validated),
+                 have been received. At that stage (after the capacity has been validated),
                  the measured delivery rate is expected to reflect the probing rate.</t>
            </list></t>
         <t>Implementation notes are provided in <xref target="req-unvalid"></xref>. </t>
     </section> <!-- End of define Unvalidated Phase -->
 
     <section anchor="sec-phase-val-phase" title="Validating Phase">
-        <t>The Validating Phase checks if all the packets
+        <t>The Validating Phase checks if the packets
         sent in the Unvalidated Phase were received without inducing congestion.
         The CWND remains unvalidated and the sender typically remains in this phase for one RTT.
         On entry to the Validating Phase, the sender:</t>
@@ -688,7 +688,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             enters the Safe Retreat Phase
             (see trigger packet_loss and ECN_CE  in <xref target="sec-QLOG"></xref>).</t>
 
-            <t>Validating Phase (Receiving acknowledgement for all unvalidated packets):
+            <t>Validating Phase (Receiving acknowledgement for the unvalidated packets):
             The sender enters the Normal Phase when an acknowledgement is
             received for the last packet number (or higher)
             that was sent in the Unvalidated Phase
@@ -753,7 +753,8 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             Unvalidated Phase and, if required,
             adjusts the ssthresh (see exit_recovery in <xref target="sec-QLOG"></xref>).
             Note: this does not imply that all packets need to be culmulatively acknowledged, only
-            that the last packet (or later) was received.
+            that all packets sent in the Unvalidated Phase have been either acknowledged
+             or have now been declared lost.
             The value of ssthresh on leaving the Safe Retreat Phase
             MUST NOT be more than the PipeSize.</t>
         </list></t>
@@ -778,7 +779,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
            that was set on entry to the Safe Retreat Phase.</t>
         
             <t><list style="symbols">
-                <t>Loss Recovery (Receiving acknowledgement for all unvalidated packets):
+                <t>Loss Recovery (Receiving acknowledgement for unvalidated packets):
                 The sender leaves the Safe Retreat Phase when
                 the last packet number (or a later packet) sent in the
                 Unvalidated Phase is acknowledged.
@@ -1094,7 +1095,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             depends on the sender policy for retransmission.
             On entry to the Safe Retreat Phase, the CWND can be
             significantly reduced, when there was multiple loss,
-            a sender recovering all lost data could take multiple RTTs to complete.</t>
+            a sender recovering all lost data could then take multiple RTTs to complete.</t>
         </list></t>
      
     </section><!-- End of Safety for the Safe Retreat Phase -->
@@ -1529,7 +1530,7 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
         from Safe Retreat, since it does indicate an upper limit to the current capacity.</t>
 
         <t>At the point where all packets sent in the Unvalidated Phase have been either acknowledged
-        or have been declared lost, the sender updates ssthresh and enters the Normal Phase.
+        or have now been declared lost, the sender updates ssthresh and enters the Normal Phase.
         Because CWND will now now be less than ssthresh, a sender in the Normal Phase is permitted to use
         Slow-Start to grow the CWND towards the ssthresh,
         after which it will enter congestion avoidance.</t>

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -644,9 +644,10 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
                  and the probing rate, multiplied by BBR.rtt_min times
                  BBRStartupCwndGain;</t>
               <t>The "carefully-resuming" flag is reset to False two rounds after
-                 it is set, i.e., after an acknowledgment indicating that the packets sent in the first round
+                 it is set, i.e., after all the packets sent in the first round
                  of "carefully resuming"
-                 have been received. At that stage (after the capacity has been validated),
+                 have been received and acknowledged by the peer.
+                At that stage (after the capacity has been validated),
                  the measured delivery rate is expected to reflect the probing rate.</t>
            </list></t>
         <t>Implementation notes are provided in <xref target="req-unvalid"></xref>. </t>

--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -689,7 +689,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             enters the Safe Retreat Phase
             (see trigger packet_loss and ECN_CE  in <xref target="sec-QLOG"></xref>).</t>
 
-            <t>Validating Phase (Receiving acknowledgement for the unvalidated packets):
+            <t>Validating Phase (Receiving acknowledgement of the unvalidated packets):
             The sender enters the Normal Phase when an acknowledgement is
             received for the last packet number (or higher)
             that was sent in the Unvalidated Phase
@@ -753,9 +753,9 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             when it receives an acknowledgement for the last packet (or a later packet) sent during the
             Unvalidated Phase and, if required,
             adjusts the ssthresh (see exit_recovery in <xref target="sec-QLOG"></xref>).
-            Note: this does not imply that all packets need to be culmulatively acknowledged, only
+            Note: this does not imply that all packets need to be cumulatively acknowledged, only
             that all packets sent in the Unvalidated Phase have been either acknowledged
-             or have now been declared lost.
+             or declared lost.
             The value of ssthresh on leaving the Safe Retreat Phase
             MUST NOT be more than the PipeSize.</t>
         </list></t>
@@ -780,7 +780,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
            that was set on entry to the Safe Retreat Phase.</t>
         
             <t><list style="symbols">
-                <t>Loss Recovery (Receiving acknowledgement for unvalidated packets):
+                <t>Loss Recovery (Receiving acknowledgement of the unvalidated packets):
                 The sender leaves the Safe Retreat Phase when
                 the last packet number (or a later packet) sent in the
                 Unvalidated Phase is acknowledged.
@@ -1095,7 +1095,7 @@ Observing ...> Connect -> Reconnaissance --------------------> Normal
             For QUIC and DCCP, the need for loss recovery
             depends on the sender policy for retransmission.
             On entry to the Safe Retreat Phase, the CWND can be
-            significantly reduced, when there was multiple loss,
+            significantly reduced. When there was multiple loss,
             a sender recovering all lost data could then take multiple RTTs to complete.</t>
         </list></t>
      
@@ -1531,7 +1531,7 @@ filing system or remote ones accessed by http (http://domain/dir/... ).-->
         from Safe Retreat, since it does indicate an upper limit to the current capacity.</t>
 
         <t>At the point where all packets sent in the Unvalidated Phase have been either acknowledged
-        or have now been declared lost, the sender updates ssthresh and enters the Normal Phase.
+        or have been declared lost, the sender updates ssthresh and enters the Normal Phase.
         Because CWND will now now be less than ssthresh, a sender in the Normal Phase is permitted to use
         Slow-Start to grow the CWND towards the ssthresh,
         after which it will enter congestion avoidance.</t>


### PR DESCRIPTION
Text to correct the action in Safe Retreat: The intention is that sender waits for an ACK indicating that all unvalidated packets had either reached the receiver or were declared lost - the old text could be read as intending that packets needed to be culmulatively ack'ed.