### PR TITLE
rate_limited trigger not mentioned

### DIFF
--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -646,7 +646,7 @@ Normal ...> Connect -> Reconnaissance --------------------> Normal
                <t>Validating Phase (Check flight_size on entry):
                On entry to the Validating Phase, if the flight_size is less
                than or equal to the PipeSize, the Normal Phase is entered with the CWND
-               reset to the PipeSize. (The PipeSize does not include the part of the 
+               reset to the PipeSize (logged as rate_limited in <xref target="I-D.custura-tsvwg-careful-resume-qlog"></xref>). (The PipeSize does not include the part of the
                jump_cwnd that was not utilised.)</t>
 
                <t>Validating Phase (Limiting CWND on entry):


### PR DESCRIPTION
The `rate_limited` trigger isn't mentioned in the draft anywhere.

Additionally, it's somewhat confusing that in the qlog document (table), `rate_limited` is triggered ("From" column) during the Unvalidated Phase, while in the CR draft, this is described in the Validating Phase section. The question is whether the entry of Validating is part of the Unvalidated phase or the Validating Phase.

If there is a better place to mention the trigger, please feel free to modify this PR.