### PR TITLE
Clarify Remote Endpoint in the Reconnaissance Phase

### DIFF
--- a/draft-ietf-tsvwg-careful-resume.xml
+++ b/draft-ietf-tsvwg-careful-resume.xml
@@ -505,10 +505,12 @@ Normal ...> Connect -> Reconnaissance --------------------> Normal
 
         <t><list style="symbols">
 
-            <t>Reconnaissance Phase (Endpoint change):
-            If the current_remote_endpoint is not the same as one of the saved_remote_endpoints,
-            the sender MUST enter the Normal Phase. (A difference in the Remote Endpoint
-            indicates a network path was different to one that was observed.)</t>
+            <t>Reconnaissance Phase (Path change):
+            If the current_remote_endpoint is not the same as a saved_remote_endpoint,
+            or receives a signal from the local stack indicates that the path is now
+            different to the observed path, the sender MUST enter the Normal Phase. (Note: A receiver
+            implementation could avoid entering the Reconnaissance Phase when the
+            curent_remote_endpoint does not match a saved_remote_endpoint.)</t>
     
         <t>Reconnaissance Phase (Lifetime of saved CC parameters): The CC parameters are temporal.
         If the LifeTime of the observed CC parameters is exceeded,


### PR DESCRIPTION
This PR clarifies the issue in #105, which was previously confusing for cases where the CC params were already available. In these cases, the CC Params could be used to avoid an unnecessary entry into the Reconnaissance Phase.
Closes #105 if merged.