### PR TITLE
use uint64 to be consistant with qlog-quic-events

### DIFF
--- a/draft-ietf-tsvwg-careful-resume-qlog-01.xml
+++ b/draft-ietf-tsvwg-careful-resume-qlog-01.xml
@@ -371,15 +371,15 @@ CarefulResumePhase =
         "safe_retreat"
 
 CarefulResumeStateParameters = {
-      pipesize: uint32,
-      first_unvalidated_packet: uint32,
-      last_unvalidated_packet: uint32,
-      ? congestion_window: uint32,
-      ? ssthresh: uint32
+      pipesize: uint64,
+      first_unvalidated_packet: uint64,
+      last_unvalidated_packet: uint64,
+      ? congestion_window: uint64,
+      ? ssthresh: uint64
 }
 
 CarefulResumeRestoredParameters = {
-      saved_congestion_window: uint32,
+      saved_congestion_window: uint64,
       saved_rtt: float32
 }
 


### PR DESCRIPTION
In Some of values that we log for careful resume are also logged in [quic-qlog-events](https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events-11) .
However, we are currently specifying smaller sizes (uint32 as opposed to uint64) for those same metrics.
I think it would therefore be better to go to uint64 for these values:

For reference:
first_unvalidated_packet, last_unvalidated_packet:
https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events-11#name-quicpacketsacked-definition

congestion_window, saved_congestion_window, ssthresh, pipesize,
https://datatracker.ietf.org/doc/html/draft-ietf-quic-qlog-quic-events-11#name-quicrecoverymetricsupdated-

